### PR TITLE
Add OpenAPI docs for API controllers

### DIFF
--- a/src/Controller/Api/AnnonceController.php
+++ b/src/Controller/Api/AnnonceController.php
@@ -12,9 +12,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Annonce')]
 class AnnonceController extends AbstractController
 {
+    #[OA\Get(path: '/api/annonces', summary: 'List annonces')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/annonces', name: 'api_annonces', methods: ['GET'])]
     public function index(AnnonceRepository $annonceRepository, ParameterBagInterface $params): JsonResponse
     {
@@ -42,6 +46,8 @@ class AnnonceController extends AbstractController
         return $this->json($data);
     }
 
+    #[OA\Post(path: '/api/annonces', summary: 'Create annonce')]
+    #[OA\Response(response: 201, description: 'Created')]
     #[Route('/api/annonces', name: 'api_annonces_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -85,6 +91,8 @@ class AnnonceController extends AbstractController
         ], 201);
     }
 
+    #[OA\Put(path: '/api/annonces/{id}', summary: 'Edit annonce')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/annonces/{id}', name: 'api_annonces_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Annonce $annonce): JsonResponse
     {
@@ -103,6 +111,8 @@ class AnnonceController extends AbstractController
         return $this->json(['status' => 'Annonce updated']);
     }
 
+    #[OA\Delete(path: '/api/annonces/{id}', summary: 'Delete annonce')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/annonces/{id}', name: 'api_annonces_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, Annonce $annonce): JsonResponse
     {

--- a/src/Controller/Api/AuthController.php
+++ b/src/Controller/Api/AuthController.php
@@ -10,9 +10,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Auth')]
 class AuthController extends AbstractController
 {
+    #[OA\Post(path: '/api/register', summary: 'Register new user')]
+    #[OA\Response(response: 201, description: 'Created')]
     #[Route('/api/register', name: 'api_register', methods: ['POST'])]
     public function register(
         Request $request,
@@ -56,6 +60,8 @@ class AuthController extends AbstractController
         return $this->json(['id' => $utilisateur->getId()], 201);
     }
 
+    #[OA\Post(path: '/api/login', summary: 'User login')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/login', name: 'api_login', methods: ['POST'])]
     public function login(
         Request $request,

--- a/src/Controller/Api/ConversationController.php
+++ b/src/Controller/Api/ConversationController.php
@@ -9,9 +9,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Conversation')]
 class ConversationController extends AbstractController
 {
+    #[OA\Get(path: '/api/conversations', summary: 'List conversations')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/conversations', name: 'api_conversations', methods: ['GET'])]
     public function index(ConversationRepository $conversationRepository): JsonResponse
     {
@@ -28,6 +32,8 @@ class ConversationController extends AbstractController
         return $this->json($data);
     }
 
+    #[OA\Post(path: '/api/conversations', summary: 'Create conversation')]
+    #[OA\Response(response: 201, description: 'Created')]
     #[Route('/api/conversations', name: 'api_conversations_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -44,6 +50,8 @@ class ConversationController extends AbstractController
         return $this->json(['id' => $conversation->getId()], 201);
     }
 
+    #[OA\Put(path: '/api/conversations/{id}', summary: 'Edit conversation')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/conversations/{id}', name: 'api_conversations_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Conversation $conversation): JsonResponse
     {
@@ -58,6 +66,8 @@ class ConversationController extends AbstractController
         return $this->json(['status' => 'Conversation updated']);
     }
 
+    #[OA\Delete(path: '/api/conversations/{id}', summary: 'Delete conversation')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/conversations/{id}', name: 'api_conversations_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, Conversation $conversation): JsonResponse
     {

--- a/src/Controller/Api/MailApiController.php
+++ b/src/Controller/Api/MailApiController.php
@@ -9,9 +9,13 @@ use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Mail')]
 class MailApiController extends AbstractController
 {
+    #[OA\Get(path: '/test-email', summary: 'Send test email')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/test-email', name: 'test_email')]
     public function send(MailerInterface $mailer): Response
     {

--- a/src/Controller/Api/MessageController.php
+++ b/src/Controller/Api/MessageController.php
@@ -9,9 +9,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Message')]
 class MessageController extends AbstractController
 {
+    #[OA\Get(path: '/api/messages', summary: 'List messages')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/messages', name: 'api_messages', methods: ['GET'])]
     public function index(MessageRepository $messageRepository): JsonResponse
     {
@@ -29,6 +33,8 @@ class MessageController extends AbstractController
         return $this->json($data);
     }
 
+    #[OA\Post(path: '/api/messages', summary: 'Create message')]
+    #[OA\Response(response: 201, description: 'Created')]
     #[Route('/api/messages', name: 'api_messages_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -46,6 +52,8 @@ class MessageController extends AbstractController
         return $this->json(['id' => $message->getId()], 201);
     }
 
+    #[OA\Put(path: '/api/messages/{id}', summary: 'Edit message')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/messages/{id}', name: 'api_messages_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Message $message): JsonResponse
     {
@@ -61,6 +69,8 @@ class MessageController extends AbstractController
         return $this->json(['status' => 'Message updated']);
     }
 
+    #[OA\Delete(path: '/api/messages/{id}', summary: 'Delete message')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/messages/{id}', name: 'api_messages_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, Message $message): JsonResponse
     {

--- a/src/Controller/Api/PhotoController.php
+++ b/src/Controller/Api/PhotoController.php
@@ -11,9 +11,13 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Photo')]
 class PhotoController extends AbstractController
 {
+    #[OA\Get(path: '/api/photos', summary: 'List photos')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/photos', name: 'api_photos', methods: ['GET'])]
     public function index(PhotoRepository $photoRepository): JsonResponse
     {
@@ -32,6 +36,8 @@ class PhotoController extends AbstractController
         return $this->json($data);
     }
 
+    #[OA\Post(path: '/api/photos', summary: 'Create photo')]
+    #[OA\Response(response: 201, description: 'Created')]
     #[Route('/api/photos', name: 'api_photos_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -49,6 +55,8 @@ class PhotoController extends AbstractController
         return $this->json(['id' => $photo->getId()], 201);
     }
 
+    #[OA\Put(path: '/api/photos/{id}', summary: 'Edit photo')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/photos/{id}', name: 'api_photos_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Photo $photo): JsonResponse
     {
@@ -64,6 +72,8 @@ class PhotoController extends AbstractController
         return $this->json(['status' => 'Photo updated']);
     }
 
+    #[OA\Delete(path: '/api/photos/{id}', summary: 'Delete photo')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/photos/{id}', name: 'api_photos_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, Photo $photo): JsonResponse
     {

--- a/src/Controller/Api/ReservationController.php
+++ b/src/Controller/Api/ReservationController.php
@@ -9,9 +9,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Reservation')]
 class ReservationController extends AbstractController
 {
+    #[OA\Get(path: '/api/reservations', summary: 'List reservations')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/reservations', name: 'api_reservations', methods: ['GET'])]
     public function index(ReservationRepository $reservationRepository): JsonResponse
     {
@@ -30,6 +34,8 @@ class ReservationController extends AbstractController
         return $this->json($data);
     }
 
+    #[OA\Post(path: '/api/reservations', summary: 'Create reservation')]
+    #[OA\Response(response: 201, description: 'Created')]
     #[Route('/api/reservations', name: 'api_reservations_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -50,6 +56,8 @@ class ReservationController extends AbstractController
         return $this->json(['id' => $reservation->getId()], 201);
     }
 
+    #[OA\Put(path: '/api/reservations/{id}', summary: 'Edit reservation')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/reservations/{id}', name: 'api_reservations_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Reservation $reservation): JsonResponse
     {
@@ -68,6 +76,8 @@ class ReservationController extends AbstractController
         return $this->json(['status' => 'Reservation updated']);
     }
 
+    #[OA\Delete(path: '/api/reservations/{id}', summary: 'Delete reservation')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/reservations/{id}', name: 'api_reservations_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, Reservation $reservation): JsonResponse
     {

--- a/src/Controller/Api/StripeController.php
+++ b/src/Controller/Api/StripeController.php
@@ -8,9 +8,13 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Stripe')]
 class StripeController extends AbstractController
 {
+    #[OA\Post(path: '/api/create-payment-intent', summary: 'Create payment intent')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/create-payment-intent', name: 'create_payment_intent', methods: ['POST'])]
     public function createPaymentIntent(Request $request): JsonResponse
     {

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -6,15 +6,19 @@ namespace App\Controller\Api;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'User')]
 class UserController extends AbstractController
 {
-#[Route('/api/users', name: 'api_users', methods: ['GET'])]
-public function index(): JsonResponse
-{
-return $this->json([
-['id' => 1, 'name' => 'Alice'],
-['id' => 2, 'name' => 'Bob'],
-]);
-}
+    #[OA\Get(path: '/api/users', summary: 'List users')]
+    #[OA\Response(response: 200, description: 'Success')]
+    #[Route('/api/users', name: 'api_users', methods: ['GET'])]
+    public function index(): JsonResponse
+    {
+        return $this->json([
+            ['id' => 1, 'name' => 'Alice'],
+            ['id' => 2, 'name' => 'Bob'],
+        ]);
+    }
 }

--- a/src/Controller/Api/UtilisateurController.php
+++ b/src/Controller/Api/UtilisateurController.php
@@ -9,9 +9,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Utilisateur')]
 class UtilisateurController extends AbstractController
 {
+    #[OA\Get(path: '/api/utilisateurs', summary: 'List utilisateurs')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/utilisateurs', name: 'api_utilisateurs', methods: ['GET'])]
     public function index(UtilisateurRepository $utilisateurRepository): JsonResponse
     {
@@ -38,6 +42,8 @@ class UtilisateurController extends AbstractController
         return $this->json($data);
     }
 
+    #[OA\Post(path: '/api/utilisateurs', summary: 'Create utilisateur')]
+    #[OA\Response(response: 201, description: 'Created')]
     #[Route('/api/utilisateurs', name: 'api_utilisateurs_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -65,6 +71,8 @@ class UtilisateurController extends AbstractController
         return $this->json(['id' => $utilisateur->getId()], 201);
     }
 
+    #[OA\Put(path: '/api/utilisateurs/{id}', summary: 'Edit utilisateur')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/utilisateurs/{id}', name: 'api_utilisateurs_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Utilisateur $utilisateur): JsonResponse
     {
@@ -112,6 +120,8 @@ class UtilisateurController extends AbstractController
         return $this->json(['status' => 'Utilisateur updated']);
     }
 
+    #[OA\Delete(path: '/api/utilisateurs/{id}', summary: 'Delete utilisateur')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/utilisateurs/{id}', name: 'api_utilisateurs_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, Utilisateur $utilisateur): JsonResponse
     {

--- a/src/Controller/Api/UtilisateurConversationController.php
+++ b/src/Controller/Api/UtilisateurConversationController.php
@@ -9,9 +9,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'UtilisateurConversation')]
 class UtilisateurConversationController extends AbstractController
 {
+    #[OA\Get(path: '/api/utilisateur-conversations', summary: 'List utilisateur conversations')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/utilisateur-conversations', name: 'api_utilisateur_conversations', methods: ['GET'])]
     public function index(UtilisateurConversationRepository $repository): JsonResponse
     {
@@ -29,6 +33,8 @@ class UtilisateurConversationController extends AbstractController
         return $this->json($data);
     }
 
+    #[OA\Post(path: '/api/utilisateur-conversations', summary: 'Create utilisateur conversation')]
+    #[OA\Response(response: 201, description: 'Created')]
     #[Route('/api/utilisateur-conversations', name: 'api_utilisateur_conversations_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -42,6 +48,8 @@ class UtilisateurConversationController extends AbstractController
         return $this->json(['id' => $item->getId()], 201);
     }
 
+    #[OA\Put(path: '/api/utilisateur-conversations/{id}', summary: 'Edit utilisateur conversation')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/utilisateur-conversations/{id}', name: 'api_utilisateur_conversations_edit', methods: ['PUT'])]
     public function edit(EntityManagerInterface $entityManager, UtilisateurConversation $utilisateurConversation): JsonResponse
     {
@@ -51,6 +59,8 @@ class UtilisateurConversationController extends AbstractController
         return $this->json(['status' => 'UtilisateurConversation updated']);
     }
 
+    #[OA\Delete(path: '/api/utilisateur-conversations/{id}', summary: 'Delete utilisateur conversation')]
+    #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/utilisateur-conversations/{id}', name: 'api_utilisateur_conversations_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, UtilisateurConversation $utilisateurConversation): JsonResponse
     {


### PR DESCRIPTION
## Summary
- add `OpenApi\Attributes` imports
- document endpoints with `OA\Get`, `OA\Post`, etc
- group controller endpoints with `OA\Tag`

## Testing
- `composer validate --no-interaction`

------
https://chatgpt.com/codex/tasks/task_e_687564bb49c083319e3de6a7068388b3