### PR TITLE
Document POST/PUT request bodies in API controllers

### DIFF
--- a/src/Controller/Api/AnnonceController.php
+++ b/src/Controller/Api/AnnonceController.php
@@ -48,6 +48,27 @@ class AnnonceController extends AbstractController
 
     #[OA\Post(path: '/api/annonces', summary: 'Create annonce')]
     #[OA\Response(response: 201, description: 'Created')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\MediaType(
+            mediaType: 'multipart/form-data',
+            schema: new OA\Schema(
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'titre', type: 'string'),
+                    new OA\Property(property: 'description', type: 'string'),
+                    new OA\Property(property: 'prix', type: 'number', format: 'float'),
+                    new OA\Property(property: 'statut', type: 'string'),
+                    new OA\Property(property: 'dateCreation', type: 'string', format: 'date-time'),
+                    new OA\Property(
+                        property: 'photos',
+                        type: 'array',
+                        items: new OA\Items(type: 'string', format: 'binary')
+                    )
+                ]
+            )
+        )
+    )]
     #[Route('/api/annonces', name: 'api_annonces_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -93,6 +114,19 @@ class AnnonceController extends AbstractController
 
     #[OA\Put(path: '/api/annonces/{id}', summary: 'Edit annonce')]
     #[OA\Response(response: 200, description: 'Success')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'titre', type: 'string'),
+                new OA\Property(property: 'description', type: 'string'),
+                new OA\Property(property: 'prix', type: 'number', format: 'float'),
+                new OA\Property(property: 'statut', type: 'string'),
+                new OA\Property(property: 'dateCreation', type: 'string', format: 'date-time')
+            ]
+        )
+    )]
     #[Route('/api/annonces/{id}', name: 'api_annonces_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Annonce $annonce): JsonResponse
     {

--- a/src/Controller/Api/AuthController.php
+++ b/src/Controller/Api/AuthController.php
@@ -17,6 +17,27 @@ class AuthController extends AbstractController
 {
     #[OA\Post(path: '/api/register', summary: 'Register new user')]
     #[OA\Response(response: 201, description: 'Created')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['email', 'password'],
+            properties: [
+                new OA\Property(property: 'email', type: 'string'),
+                new OA\Property(property: 'password', type: 'string'),
+                new OA\Property(property: 'roles', type: 'array', items: new OA\Items(type: 'string')),
+                new OA\Property(property: 'nom', type: 'string'),
+                new OA\Property(property: 'prenom', type: 'string'),
+                new OA\Property(property: 'dateInscription', type: 'string', format: 'date-time'),
+                new OA\Property(property: 'cagnotte', type: 'number', format: 'float'),
+                new OA\Property(property: 'emailIsVerified', type: 'boolean'),
+                new OA\Property(property: 'adresse', type: 'string'),
+                new OA\Property(property: 'postalCode', type: 'string'),
+                new OA\Property(property: 'ville', type: 'string'),
+                new OA\Property(property: 'pays', type: 'string')
+            ]
+        )
+    )]
     #[Route('/api/register', name: 'api_register', methods: ['POST'])]
     public function register(
         Request $request,
@@ -62,6 +83,17 @@ class AuthController extends AbstractController
 
     #[OA\Post(path: '/api/login', summary: 'User login')]
     #[OA\Response(response: 200, description: 'Success')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['email', 'password'],
+            properties: [
+                new OA\Property(property: 'email', type: 'string'),
+                new OA\Property(property: 'password', type: 'string')
+            ]
+        )
+    )]
     #[Route('/api/login', name: 'api_login', methods: ['POST'])]
     public function login(
         Request $request,

--- a/src/Controller/Api/ConversationController.php
+++ b/src/Controller/Api/ConversationController.php
@@ -34,6 +34,14 @@ class ConversationController extends AbstractController
 
     #[OA\Post(path: '/api/conversations', summary: 'Create conversation')]
     #[OA\Response(response: 201, description: 'Created')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'dateCreation', type: 'string', format: 'date-time')
+            ]
+        )
+    )]
     #[Route('/api/conversations', name: 'api_conversations_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -52,6 +60,14 @@ class ConversationController extends AbstractController
 
     #[OA\Put(path: '/api/conversations/{id}', summary: 'Edit conversation')]
     #[OA\Response(response: 200, description: 'Success')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'dateCreation', type: 'string', format: 'date-time')
+            ]
+        )
+    )]
     #[Route('/api/conversations/{id}', name: 'api_conversations_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Conversation $conversation): JsonResponse
     {

--- a/src/Controller/Api/MessageController.php
+++ b/src/Controller/Api/MessageController.php
@@ -35,6 +35,15 @@ class MessageController extends AbstractController
 
     #[OA\Post(path: '/api/messages', summary: 'Create message')]
     #[OA\Response(response: 201, description: 'Created')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'contenu', type: 'string'),
+                new OA\Property(property: 'dateEnvoi', type: 'string', format: 'date-time')
+            ]
+        )
+    )]
     #[Route('/api/messages', name: 'api_messages_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -54,6 +63,15 @@ class MessageController extends AbstractController
 
     #[OA\Put(path: '/api/messages/{id}', summary: 'Edit message')]
     #[OA\Response(response: 200, description: 'Success')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'contenu', type: 'string'),
+                new OA\Property(property: 'dateEnvoi', type: 'string', format: 'date-time')
+            ]
+        )
+    )]
     #[Route('/api/messages/{id}', name: 'api_messages_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Message $message): JsonResponse
     {

--- a/src/Controller/Api/PhotoController.php
+++ b/src/Controller/Api/PhotoController.php
@@ -38,6 +38,15 @@ class PhotoController extends AbstractController
 
     #[OA\Post(path: '/api/photos', summary: 'Create photo')]
     #[OA\Response(response: 201, description: 'Created')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'urlChemin', type: 'string'),
+                new OA\Property(property: 'dateUpload', type: 'string', format: 'date-time')
+            ]
+        )
+    )]
     #[Route('/api/photos', name: 'api_photos_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -57,6 +66,15 @@ class PhotoController extends AbstractController
 
     #[OA\Put(path: '/api/photos/{id}', summary: 'Edit photo')]
     #[OA\Response(response: 200, description: 'Success')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'urlChemin', type: 'string'),
+                new OA\Property(property: 'dateUpload', type: 'string', format: 'date-time')
+            ]
+        )
+    )]
     #[Route('/api/photos/{id}', name: 'api_photos_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Photo $photo): JsonResponse
     {

--- a/src/Controller/Api/ReservationController.php
+++ b/src/Controller/Api/ReservationController.php
@@ -36,6 +36,16 @@ class ReservationController extends AbstractController
 
     #[OA\Post(path: '/api/reservations', summary: 'Create reservation')]
     #[OA\Response(response: 201, description: 'Created')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'dateDebut', type: 'string', format: 'date-time'),
+                new OA\Property(property: 'dateFin', type: 'string', format: 'date-time'),
+                new OA\Property(property: 'statut', type: 'string')
+            ]
+        )
+    )]
     #[Route('/api/reservations', name: 'api_reservations_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -58,6 +68,16 @@ class ReservationController extends AbstractController
 
     #[OA\Put(path: '/api/reservations/{id}', summary: 'Edit reservation')]
     #[OA\Response(response: 200, description: 'Success')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'dateDebut', type: 'string', format: 'date-time'),
+                new OA\Property(property: 'dateFin', type: 'string', format: 'date-time'),
+                new OA\Property(property: 'statut', type: 'string')
+            ]
+        )
+    )]
     #[Route('/api/reservations/{id}', name: 'api_reservations_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Reservation $reservation): JsonResponse
     {

--- a/src/Controller/Api/StripeController.php
+++ b/src/Controller/Api/StripeController.php
@@ -15,6 +15,14 @@ class StripeController extends AbstractController
 {
     #[OA\Post(path: '/api/create-payment-intent', summary: 'Create payment intent')]
     #[OA\Response(response: 200, description: 'Success')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'amount', type: 'integer')
+            ]
+        )
+    )]
     #[Route('/api/create-payment-intent', name: 'create_payment_intent', methods: ['POST'])]
     public function createPaymentIntent(Request $request): JsonResponse
     {

--- a/src/Controller/Api/UtilisateurController.php
+++ b/src/Controller/Api/UtilisateurController.php
@@ -44,6 +44,27 @@ class UtilisateurController extends AbstractController
 
     #[OA\Post(path: '/api/utilisateurs', summary: 'Create utilisateur')]
     #[OA\Response(response: 201, description: 'Created')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['email', 'password'],
+            properties: [
+                new OA\Property(property: 'email', type: 'string'),
+                new OA\Property(property: 'roles', type: 'array', items: new OA\Items(type: 'string')),
+                new OA\Property(property: 'password', type: 'string'),
+                new OA\Property(property: 'nom', type: 'string'),
+                new OA\Property(property: 'prenom', type: 'string'),
+                new OA\Property(property: 'dateInscription', type: 'string', format: 'date-time'),
+                new OA\Property(property: 'cagnotte', type: 'number', format: 'float'),
+                new OA\Property(property: 'emailIsVerified', type: 'boolean'),
+                new OA\Property(property: 'adresse', type: 'string'),
+                new OA\Property(property: 'postalCode', type: 'string'),
+                new OA\Property(property: 'ville', type: 'string'),
+                new OA\Property(property: 'pays', type: 'string')
+            ]
+        )
+    )]
     #[Route('/api/utilisateurs', name: 'api_utilisateurs_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {
@@ -73,6 +94,25 @@ class UtilisateurController extends AbstractController
 
     #[OA\Put(path: '/api/utilisateurs/{id}', summary: 'Edit utilisateur')]
     #[OA\Response(response: 200, description: 'Success')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'email', type: 'string'),
+                new OA\Property(property: 'roles', type: 'array', items: new OA\Items(type: 'string')),
+                new OA\Property(property: 'password', type: 'string'),
+                new OA\Property(property: 'nom', type: 'string'),
+                new OA\Property(property: 'prenom', type: 'string'),
+                new OA\Property(property: 'dateInscription', type: 'string', format: 'date-time'),
+                new OA\Property(property: 'cagnotte', type: 'number', format: 'float'),
+                new OA\Property(property: 'emailIsVerified', type: 'boolean'),
+                new OA\Property(property: 'adresse', type: 'string'),
+                new OA\Property(property: 'postalCode', type: 'string'),
+                new OA\Property(property: 'ville', type: 'string'),
+                new OA\Property(property: 'pays', type: 'string')
+            ]
+        )
+    )]
     #[Route('/api/utilisateurs/{id}', name: 'api_utilisateurs_edit', methods: ['PUT'])]
     public function edit(Request $request, EntityManagerInterface $entityManager, Utilisateur $utilisateur): JsonResponse
     {

--- a/src/Controller/Api/UtilisateurConversationController.php
+++ b/src/Controller/Api/UtilisateurConversationController.php
@@ -35,6 +35,15 @@ class UtilisateurConversationController extends AbstractController
 
     #[OA\Post(path: '/api/utilisateur-conversations', summary: 'Create utilisateur conversation')]
     #[OA\Response(response: 201, description: 'Created')]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'utilisateurId', type: 'integer'),
+                new OA\Property(property: 'conversationId', type: 'integer')
+            ]
+        )
+    )]
     #[Route('/api/utilisateur-conversations', name: 'api_utilisateur_conversations_new', methods: ['POST'])]
     public function new(Request $request, EntityManagerInterface $entityManager): JsonResponse
     {


### PR DESCRIPTION
## Summary
- document JSON payloads with `OA\JsonContent`
- document photo uploads with multipart-form bodies

## Testing
- `composer --version`

------
https://chatgpt.com/codex/tasks/task_e_6875696f04308331b1442b418d6cc74b