### PR TITLE
Add missing entity relationships

### DIFF
--- a/src/Entity/Annonce.php
+++ b/src/Entity/Annonce.php
@@ -4,6 +4,8 @@ namespace App\Entity;
 
 use App\Repository\AnnonceRepository;
 use App\Entity\Photo;
+use App\Entity\Reservation;
+use App\Entity\Utilisateur;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -32,6 +34,15 @@ class Annonce
     #[ORM\Column(nullable: true)]
     private ?\DateTime $dateCreation = null;
 
+    #[ORM\ManyToOne(inversedBy: 'annonces')]
+    private ?Utilisateur $utilisateur = null;
+
+    /**
+     * @var Collection<int, Reservation>
+     */
+    #[ORM\OneToMany(mappedBy: 'annonce', targetEntity: Reservation::class)]
+    private Collection $reservations;
+
     /**
      * @var Collection<int, Photo>
      */
@@ -41,6 +52,7 @@ class Annonce
     public function __construct()
     {
         $this->photos = new ArrayCollection();
+        $this->reservations = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -132,6 +144,48 @@ class Annonce
             // set the owning side to null (unless already changed)
             if ($photo->getAnnonce() === $this) {
                 $photo->setAnnonce(null);
+            }
+        }
+
+        return $this;
+    }
+
+    public function getUtilisateur(): ?Utilisateur
+    {
+        return $this->utilisateur;
+    }
+
+    public function setUtilisateur(?Utilisateur $utilisateur): static
+    {
+        $this->utilisateur = $utilisateur;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Reservation>
+     */
+    public function getReservations(): Collection
+    {
+        return $this->reservations;
+    }
+
+    public function addReservation(Reservation $reservation): static
+    {
+        if (!$this->reservations->contains($reservation)) {
+            $this->reservations->add($reservation);
+            $reservation->setAnnonce($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReservation(Reservation $reservation): static
+    {
+        if ($this->reservations->removeElement($reservation)) {
+            // set the owning side to null (unless already changed)
+            if ($reservation->getAnnonce() === $this) {
+                $reservation->setAnnonce(null);
             }
         }
 

--- a/src/Entity/Conversation.php
+++ b/src/Entity/Conversation.php
@@ -6,6 +6,7 @@ use App\Repository\ConversationRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use App\Entity\Message;
 
 #[ORM\Entity(repositoryClass: ConversationRepository::class)]
 class Conversation
@@ -24,9 +25,16 @@ class Conversation
     #[ORM\OneToMany(targetEntity: UtilisateurConversation::class, mappedBy: 'conversation')]
     private Collection $utilisateurConversations;
 
+    /**
+     * @var Collection<int, Message>
+     */
+    #[ORM\OneToMany(mappedBy: 'conversation', targetEntity: Message::class, orphanRemoval: true)]
+    private Collection $messages;
+
     public function __construct()
     {
         $this->utilisateurConversations = new ArrayCollection();
+        $this->messages = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -70,6 +78,36 @@ class Conversation
             // set the owning side to null (unless already changed)
             if ($utilisateurConversation->getConversation() === $this) {
                 $utilisateurConversation->setConversation(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Message>
+     */
+    public function getMessages(): Collection
+    {
+        return $this->messages;
+    }
+
+    public function addMessage(Message $message): static
+    {
+        if (!$this->messages->contains($message)) {
+            $this->messages->add($message);
+            $message->setConversation($this);
+        }
+
+        return $this;
+    }
+
+    public function removeMessage(Message $message): static
+    {
+        if ($this->messages->removeElement($message)) {
+            // set the owning side to null (unless already changed)
+            if ($message->getConversation() === $this) {
+                $message->setConversation(null);
             }
         }
 

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
+use App\Entity\Conversation;
 
 #[ORM\Entity(repositoryClass: MessageRepository::class)]
 #[ApiResource(
@@ -37,6 +38,9 @@ class Message
     #[ORM\ManyToOne(targetEntity: Utilisateur::class)]
     #[Groups(['message:read', 'message:write'])]
     private ?Utilisateur $receiver = null;
+
+    #[ORM\ManyToOne(inversedBy: 'messages')]
+    private ?Conversation $conversation = null;
 
     public function __construct()
     {
@@ -92,6 +96,18 @@ class Message
     public function setReceiver(?Utilisateur $receiver): static
     {
         $this->receiver = $receiver;
+
+        return $this;
+    }
+
+    public function getConversation(): ?Conversation
+    {
+        return $this->conversation;
+    }
+
+    public function setConversation(?Conversation $conversation): static
+    {
+        $this->conversation = $conversation;
 
         return $this;
     }

--- a/src/Entity/Reservation.php
+++ b/src/Entity/Reservation.php
@@ -4,6 +4,8 @@ namespace App\Entity;
 
 use App\Repository\ReservationRepository;
 use Doctrine\ORM\Mapping as ORM;
+use App\Entity\Annonce;
+use App\Entity\Utilisateur;
 
 #[ORM\Entity(repositoryClass: ReservationRepository::class)]
 class Reservation
@@ -21,6 +23,12 @@ class Reservation
 
     #[ORM\Column(length: 255, nullable: true)]
     private ?string $statut = null;
+
+    #[ORM\ManyToOne(inversedBy: 'reservations')]
+    private ?Annonce $annonce = null;
+
+    #[ORM\ManyToOne(inversedBy: 'reservations')]
+    private ?Utilisateur $utilisateur = null;
 
     public function getId(): ?int
     {
@@ -59,6 +67,30 @@ class Reservation
     public function setStatut(?string $statut): static
     {
         $this->statut = $statut;
+
+        return $this;
+    }
+
+    public function getAnnonce(): ?Annonce
+    {
+        return $this->annonce;
+    }
+
+    public function setAnnonce(?Annonce $annonce): static
+    {
+        $this->annonce = $annonce;
+
+        return $this;
+    }
+
+    public function getUtilisateur(): ?Utilisateur
+    {
+        return $this->utilisateur;
+    }
+
+    public function setUtilisateur(?Utilisateur $utilisateur): static
+    {
+        $this->utilisateur = $utilisateur;
 
         return $this;
     }

--- a/src/Entity/Utilisateur.php
+++ b/src/Entity/Utilisateur.php
@@ -9,6 +9,10 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use App\Entity\UtilisateurConversation;
+use App\Entity\Message;
+use App\Entity\Annonce;
+use App\Entity\Reservation;
 
 #[ORM\Entity(repositoryClass: UtilisateurRepository::class)]
 #[ORM\UniqueConstraint(name: 'UNIQ_IDENTIFIER_EMAIL', fields: ['email'])]
@@ -73,10 +77,20 @@ class Utilisateur implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToMany(mappedBy: 'receiver', targetEntity: Message::class)]
     private Collection $receivedMessages;
 
+    #[ORM\OneToMany(mappedBy: 'utilisateur', targetEntity: Annonce::class)]
+    private Collection $annonces;
+
+    #[ORM\OneToMany(mappedBy: 'utilisateur', targetEntity: Reservation::class)]
+    private Collection $reservations;
+
 
     public function __construct()
     {
         $this->utilisateurConversations = new ArrayCollection();
+        $this->sentMessages = new ArrayCollection();
+        $this->receivedMessages = new ArrayCollection();
+        $this->annonces = new ArrayCollection();
+        $this->reservations = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -284,6 +298,126 @@ class Utilisateur implements UserInterface, PasswordAuthenticatedUserInterface
             // set the owning side to null (unless already changed)
             if ($utilisateurConversation->getUtilisateur() === $this) {
                 $utilisateurConversation->setUtilisateur(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Message>
+     */
+    public function getSentMessages(): Collection
+    {
+        return $this->sentMessages;
+    }
+
+    public function addSentMessage(Message $message): static
+    {
+        if (!$this->sentMessages->contains($message)) {
+            $this->sentMessages->add($message);
+            $message->setSender($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSentMessage(Message $message): static
+    {
+        if ($this->sentMessages->removeElement($message)) {
+            // set the owning side to null (unless already changed)
+            if ($message->getSender() === $this) {
+                $message->setSender(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Message>
+     */
+    public function getReceivedMessages(): Collection
+    {
+        return $this->receivedMessages;
+    }
+
+    public function addReceivedMessage(Message $message): static
+    {
+        if (!$this->receivedMessages->contains($message)) {
+            $this->receivedMessages->add($message);
+            $message->setReceiver($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReceivedMessage(Message $message): static
+    {
+        if ($this->receivedMessages->removeElement($message)) {
+            // set the owning side to null (unless already changed)
+            if ($message->getReceiver() === $this) {
+                $message->setReceiver(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Annonce>
+     */
+    public function getAnnonces(): Collection
+    {
+        return $this->annonces;
+    }
+
+    public function addAnnonce(Annonce $annonce): static
+    {
+        if (!$this->annonces->contains($annonce)) {
+            $this->annonces->add($annonce);
+            $annonce->setUtilisateur($this);
+        }
+
+        return $this;
+    }
+
+    public function removeAnnonce(Annonce $annonce): static
+    {
+        if ($this->annonces->removeElement($annonce)) {
+            // set the owning side to null (unless already changed)
+            if ($annonce->getUtilisateur() === $this) {
+                $annonce->setUtilisateur(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Reservation>
+     */
+    public function getReservations(): Collection
+    {
+        return $this->reservations;
+    }
+
+    public function addReservation(Reservation $reservation): static
+    {
+        if (!$this->reservations->contains($reservation)) {
+            $this->reservations->add($reservation);
+            $reservation->setUtilisateur($this);
+        }
+
+        return $this;
+    }
+
+    public function removeReservation(Reservation $reservation): static
+    {
+        if ($this->reservations->removeElement($reservation)) {
+            // set the owning side to null (unless already changed)
+            if ($reservation->getUtilisateur() === $this) {
+                $reservation->setUtilisateur(null);
             }
         }
 


### PR DESCRIPTION
## Summary
- connect `Annonce` to `Utilisateur` and `Reservation`
- connect `Reservation` to `Annonce` and `Utilisateur`
- connect `Conversation` to its `Message`s
- connect `Message` to `Conversation`
- expose related collections on `Utilisateur`

## Testing
- `composer dump-autoload --optimize`
- `composer validate --no-check-all --strict` *(fails: name & description required)*
- `php -l src/Entity/Annonce.php`
- `php -l src/Entity/Reservation.php`
- `php -l src/Entity/Conversation.php`
- `php -l src/Entity/Message.php`
- `php -l src/Entity/Utilisateur.php`


------
https://chatgpt.com/codex/tasks/task_e_687a7ab585ec83318a120c9c4f9e4632