### PR TITLE
Add conversation retrieval in MessageController

### DIFF
--- a/src/Controller/Api/MessageController.php
+++ b/src/Controller/Api/MessageController.php
@@ -101,6 +101,29 @@ class MessageController extends AbstractController
         return $id1 < $id2 ? "$id1-$id2" : "$id2-$id1";
     }
 
+    #[Route('/api/messages/conversation/{id}', name: 'get_conversation_messages', methods: ['GET'])]
+    public function getConversationMessages(
+        Utilisateur $id,
+        MessageRepository $repository,
+        Security $security
+    ): JsonResponse {
+        $currentUser = $security->getUser();
+
+        $messages = $repository->findConversationMessages($currentUser, $id);
+
+        $data = array_map(static function (Message $message) {
+            return [
+                'id' => $message->getId(),
+                'contenu' => $message->getContenu(),
+                'from' => $message->getSender()?->getId(),
+                'to' => $message->getReceiver()?->getId(),
+                'date' => $message->getDateEnvoi()?->format('Y-m-d H:i'),
+            ];
+        }, $messages);
+
+        return $this->json($data);
+    }
+
     #[OA\Put(path: '/api/messages/{id}', summary: 'Edit message')]
     #[OA\Response(response: 200, description: 'Success')]
     #[OA\RequestBody(

--- a/src/Repository/MessageRepository.php
+++ b/src/Repository/MessageRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Message;
+use App\Entity\Utilisateur;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -14,6 +15,20 @@ class MessageRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Message::class);
+    }
+
+    /**
+     * Retrieve all messages exchanged between two users ordered by date.
+     */
+    public function findConversationMessages(Utilisateur $userA, Utilisateur $userB): array
+    {
+        return $this->createQueryBuilder('m')
+            ->andWhere('(m.sender = :a AND m.receiver = :b) OR (m.sender = :b AND m.receiver = :a)')
+            ->setParameter('a', $userA)
+            ->setParameter('b', $userB)
+            ->orderBy('m.dateEnvoi', 'ASC')
+            ->getQuery()
+            ->getResult();
     }
 
     //    /**


### PR DESCRIPTION
## Summary
- add helper in MessageRepository to fetch messages exchanged between two users
- expose a new route in MessageController to list conversation messages

## Testing
- `php -l src/Repository/MessageRepository.php`
- `php -l src/Controller/Api/MessageController.php`

------
https://chatgpt.com/codex/tasks/task_e_687a7d630dec8331860a2933374933cd