### PR TITLE
Add favoris relation between utilisateurs and annonces

### DIFF
--- a/src/Entity/Annonce.php
+++ b/src/Entity/Annonce.php
@@ -55,11 +55,18 @@ class Annonce
     #[ORM\ManyToMany(targetEntity: Categorie::class, inversedBy: 'annonces')]
     private Collection $categorie;
 
+    /**
+     * @var Collection<int, Utilisateur>
+     */
+    #[ORM\ManyToMany(targetEntity: Utilisateur::class, mappedBy: 'favoris')]
+    private Collection $favoris;
+
     public function __construct()
     {
         $this->photos = new ArrayCollection();
         $this->reservations = new ArrayCollection();
         $this->categorie = new ArrayCollection();
+        $this->favoris = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -219,6 +226,33 @@ class Annonce
     public function removeCategorie(Categorie $categorie): static
     {
         $this->categorie->removeElement($categorie);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Utilisateur>
+     */
+    public function getFavoris(): Collection
+    {
+        return $this->favoris;
+    }
+
+    public function addFavori(Utilisateur $utilisateur): static
+    {
+        if (!$this->favoris->contains($utilisateur)) {
+            $this->favoris->add($utilisateur);
+            $utilisateur->addFavori($this);
+        }
+
+        return $this;
+    }
+
+    public function removeFavori(Utilisateur $utilisateur): static
+    {
+        if ($this->favoris->removeElement($utilisateur)) {
+            $utilisateur->removeFavori($this);
+        }
 
         return $this;
     }

--- a/src/Entity/Utilisateur.php
+++ b/src/Entity/Utilisateur.php
@@ -83,6 +83,12 @@ class Utilisateur implements UserInterface, PasswordAuthenticatedUserInterface
     #[ORM\OneToMany(mappedBy: 'utilisateur', targetEntity: Reservation::class)]
     private Collection $reservations;
 
+    /**
+     * @var Collection<int, Annonce>
+     */
+    #[ORM\ManyToMany(targetEntity: Annonce::class, inversedBy: 'favoris')]
+    private Collection $favoris;
+
 
     public function __construct()
     {
@@ -91,6 +97,7 @@ class Utilisateur implements UserInterface, PasswordAuthenticatedUserInterface
         $this->receivedMessages = new ArrayCollection();
         $this->annonces = new ArrayCollection();
         $this->reservations = new ArrayCollection();
+        $this->favoris = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -419,6 +426,33 @@ class Utilisateur implements UserInterface, PasswordAuthenticatedUserInterface
             if ($reservation->getUtilisateur() === $this) {
                 $reservation->setUtilisateur(null);
             }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Annonce>
+     */
+    public function getFavoris(): Collection
+    {
+        return $this->favoris;
+    }
+
+    public function addFavori(Annonce $annonce): static
+    {
+        if (!$this->favoris->contains($annonce)) {
+            $this->favoris->add($annonce);
+            $annonce->addFavori($this);
+        }
+
+        return $this;
+    }
+
+    public function removeFavori(Annonce $annonce): static
+    {
+        if ($this->favoris->removeElement($annonce)) {
+            $annonce->removeFavori($this);
         }
 
         return $this;


### PR DESCRIPTION
## Summary
- establish a ManyToMany relation between `Utilisateur` and `Annonce`
- provide accessor and mutator helpers for the favourites
- include initialization of the new collections

## Testing
- `php -l src/Entity/Utilisateur.php`
- `php -l src/Entity/Annonce.php`
- `php bin/console make:migration` *(fails: Symfony Runtime missing)*
- `php bin/console doctrine:migrations:migrate --no-interaction` *(fails: Symfony Runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b97a9818883318892fd16e96e59d2