### PR TITLE
Enhance conversation message retrieval

### DIFF
--- a/src/Controller/Api/MessageController.php
+++ b/src/Controller/Api/MessageController.php
@@ -4,7 +4,8 @@ namespace App\Controller\Api;
 
 use App\Entity\Message;
 use App\Entity\Utilisateur;
-use App\Repository\MessageRepository;
+use App\Repository\ConversationRepository;
+use App\Repository\UtilisateurRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
@@ -126,13 +127,27 @@ class MessageController extends AbstractController
 
     #[Route('/api/secure/messages/conversation/{id}', name: 'get_conversation_messages', methods: ['GET'])]
     public function getConversationMessages(
-        Utilisateur $id,
-        MessageRepository $repository,
+        int $id,
+        ConversationRepository $conversationRepository,
+        UtilisateurRepository $utilisateurRepository,
         Security $security
     ): JsonResponse {
         $currentUser = $security->getUser();
 
-        $messages = $repository->findConversationMessages($currentUser, $id);
+        $conversation = $conversationRepository->find($id);
+
+        if (!$conversation) {
+            $otherUser = $utilisateurRepository->find($id);
+            if (!$otherUser) {
+                return $this->json(['error' => 'Conversation not found'], 404);
+            }
+            $conversation = $conversationRepository->findByParticipants($currentUser, $otherUser);
+            if (!$conversation) {
+                return $this->json([]);
+            }
+        }
+
+        $messages = $conversation->getMessages();
 
         $data = array_map(static function (Message $message) {
             return [
@@ -142,7 +157,7 @@ class MessageController extends AbstractController
                 'to' => $message->getReceiver()?->getId(),
                 'date' => $message->getDateEnvoi()?->format('Y-m-d H:i'),
             ];
-        }, $messages);
+        }, $messages->toArray());
 
         return $this->json($data);
     }

--- a/src/Repository/ConversationRepository.php
+++ b/src/Repository/ConversationRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Conversation;
+use App\Entity\Utilisateur;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -14,6 +15,22 @@ class ConversationRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Conversation::class);
+    }
+
+    /**
+     * Find a conversation between two participants.
+     */
+    public function findByParticipants(Utilisateur $a, Utilisateur $b): ?Conversation
+    {
+        return $this->createQueryBuilder('c')
+            ->innerJoin('c.utilisateurConversations', 'ua')
+            ->innerJoin('c.utilisateurConversations', 'ub')
+            ->andWhere('ua.utilisateur = :a')
+            ->andWhere('ub.utilisateur = :b')
+            ->setParameter('a', $a)
+            ->setParameter('b', $b)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 
     //    /**


### PR DESCRIPTION
## Summary
- support finding conversations by participants
- fetch conversation messages using a conversation or participant id

## Testing
- `composer validate --strict` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc50972488331ae790eca0a71c068