### PR TITLE
Add conversation and author fields to Message entity

### DIFF
--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -20,6 +20,12 @@ class Message
     #[ORM\Column(nullable: true)]
     private ?\DateTime $dateEnvoi = null;
 
+    #[ORM\ManyToOne(inversedBy: 'messages')]
+    private ?Conversation $conversation = null;
+
+    #[ORM\ManyToOne]
+    private ?Utilisateur $author = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -45,6 +51,30 @@ class Message
     public function setDateEnvoi(?\DateTime $dateEnvoi): static
     {
         $this->dateEnvoi = $dateEnvoi;
+
+        return $this;
+    }
+
+    public function getConversation(): ?Conversation
+    {
+        return $this->conversation;
+    }
+
+    public function setConversation(?Conversation $conversation): static
+    {
+        $this->conversation = $conversation;
+
+        return $this;
+    }
+
+    public function getAuthor(): ?Utilisateur
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?Utilisateur $author): static
+    {
+        $this->author = $author;
 
         return $this;
     }


### PR DESCRIPTION
## Summary
- add Conversation and Utilisateur relations to `Message`
- generate getters and setters for new fields

## Testing
- `composer validate --strict`
- `php -l src/Entity/Message.php`


------
https://chatgpt.com/codex/tasks/task_e_687bcc972f2c8331a219791697f726d9