### PR TITLE
Add Conversation messages relation

### DIFF
--- a/src/Entity/Conversation.php
+++ b/src/Entity/Conversation.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\ConversationRepository;
+use App\Entity\Message;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -24,9 +25,16 @@ class Conversation
     #[ORM\OneToMany(targetEntity: UtilisateurConversation::class, mappedBy: 'conversation')]
     private Collection $utilisateurConversations;
 
+    /**
+     * @var Collection<int, Message>
+     */
+    #[ORM\OneToMany(mappedBy: 'conversation', targetEntity: Message::class)]
+    private Collection $messages;
+
     public function __construct()
     {
         $this->utilisateurConversations = new ArrayCollection();
+        $this->messages = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -70,6 +78,36 @@ class Conversation
             // set the owning side to null (unless already changed)
             if ($utilisateurConversation->getConversation() === $this) {
                 $utilisateurConversation->setConversation(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Message>
+     */
+    public function getMessages(): Collection
+    {
+        return $this->messages;
+    }
+
+    public function addMessage(Message $message): static
+    {
+        if (!$this->messages->contains($message)) {
+            $this->messages->add($message);
+            $message->setConversation($this);
+        }
+
+        return $this;
+    }
+
+    public function removeMessage(Message $message): static
+    {
+        if ($this->messages->removeElement($message)) {
+            // set the owning side to null (unless already changed)
+            if ($message->getConversation() === $this) {
+                $message->setConversation(null);
             }
         }
 


### PR DESCRIPTION
## Summary
- add `Message` import
- map `messages` relation in `Conversation`
- construct messages collection
- add accessors for messages

## Testing
- `php -l src/Entity/Conversation.php`
- `composer validate --no-check-all`

------
https://chatgpt.com/codex/tasks/task_e_687bcca14dc48331a246407af6977ebb