### PR TITLE
Add Transaction entity and repository

### DIFF
--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\TransactionRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: TransactionRepository::class)]
+class Transaction
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $stripeIntentId = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?float $amount = null;
+
+    #[ORM\Column(length: 10, nullable: true)]
+    private ?string $currency = null;
+
+    #[ORM\Column(length: 50, nullable: true)]
+    private ?string $status = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTime $createdAt = null;
+
+    #[ORM\ManyToOne]
+    private ?Reservation $reservation = null;
+
+    #[ORM\ManyToOne]
+    private ?Utilisateur $utilisateur = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getStripeIntentId(): ?string
+    {
+        return $this->stripeIntentId;
+    }
+
+    public function setStripeIntentId(?string $stripeIntentId): static
+    {
+        $this->stripeIntentId = $stripeIntentId;
+
+        return $this;
+    }
+
+    public function getAmount(): ?float
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(?float $amount): static
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getCurrency(): ?string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(?string $currency): static
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(?string $status): static
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTime $createdAt): static
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getReservation(): ?Reservation
+    {
+        return $this->reservation;
+    }
+
+    public function setReservation(?Reservation $reservation): static
+    {
+        $this->reservation = $reservation;
+
+        return $this;
+    }
+
+    public function getUtilisateur(): ?Utilisateur
+    {
+        return $this->utilisateur;
+    }
+
+    public function setUtilisateur(?Utilisateur $utilisateur): static
+    {
+        $this->utilisateur = $utilisateur;
+
+        return $this;
+    }
+}

--- a/src/Repository/TransactionRepository.php
+++ b/src/Repository/TransactionRepository.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Transaction;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Transaction>
+ */
+class TransactionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Transaction::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Transaction` entity
- generate `TransactionRepository`

## Testing
- `composer validate --no-interaction`
- `php -l src/Entity/Transaction.php`
- `php -l src/Repository/TransactionRepository.php`


------
https://chatgpt.com/codex/tasks/task_e_687cfd52d6b08331b8a78235e7fb50a8