### PR TITLE
Secure utilisateur delete route

### DIFF
--- a/src/Controller/Api/UtilisateurController.php
+++ b/src/Controller/Api/UtilisateurController.php
@@ -192,7 +192,7 @@ class UtilisateurController extends AbstractController
 
     #[OA\Delete(path: '/api/secure/utilisateurs/{id}', summary: 'Delete utilisateur')]
     #[OA\Response(response: 200, description: 'Success')]
-    #[Route('/api/utilisateurs/{id}', name: 'api_utilisateurs_delete', methods: ['DELETE'])]
+    #[Route('/api/secure/utilisateurs/{id}', name: 'api_utilisateurs_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, Utilisateur $utilisateur): JsonResponse
     {
         $data[] = [


### PR DESCRIPTION
## Summary
- enforce secure prefix for delete utilisateur route

## Testing
- `grep -n "api_.*delete" -n src/Controller/Api/UtilisateurController.php`


------
https://chatgpt.com/codex/tasks/task_e_687d04391a3883319a7966b839519555