### PR TITLE
Secure certain API endpoints

### DIFF
--- a/src/Controller/Api/MailApiController.php
+++ b/src/Controller/Api/MailApiController.php
@@ -38,7 +38,7 @@ class MailApiController extends AbstractController
         return new Response('✅ Mail envoyé !');
     }
 
-    #[OA\Post(path: '/api/mail/send', summary: 'Send a custom email with image')]
+    #[OA\Post(path: '/api/secure/mail/send', summary: 'Send a custom email with image')]
     #[OA\RequestBody(
         required: true,
         content: new OA\JsonContent(
@@ -52,7 +52,7 @@ class MailApiController extends AbstractController
         )
     )]
     #[OA\Response(response: 200, description: 'Mail sent successfully')]
-    #[Route('/api/mail/send', name: 'api_mail_send', methods: ['POST'])]
+    #[Route('/api/secure/mail/send', name: 'api_mail_send', methods: ['POST'])]
     public function sendMail(Request $request, MailerInterface $mailer): JsonResponse
     {
         $data = json_decode($request->getContent(), true);

--- a/src/Controller/Api/StripeController.php
+++ b/src/Controller/Api/StripeController.php
@@ -13,7 +13,7 @@ use OpenApi\Attributes as OA;
 #[OA\Tag(name: 'Stripe')]
 class StripeController extends AbstractController
 {
-    #[OA\Post(path: '/api/create-payment-intent', summary: 'Create payment intent')]
+    #[OA\Post(path: '/api/secure/create-payment-intent', summary: 'Create payment intent')]
     #[OA\Response(response: 200, description: 'Success')]
     #[OA\RequestBody(
         content: new OA\JsonContent(
@@ -23,7 +23,7 @@ class StripeController extends AbstractController
             ]
         )
     )]
-    #[Route('/api/create-payment-intent', name: 'create_payment_intent', methods: ['POST'])]
+    #[Route('/api/secure/create-payment-intent', name: 'create_payment_intent', methods: ['POST'])]
     public function createPaymentIntent(Request $request): JsonResponse
     {
         \Stripe\Stripe::setApiKey($_ENV['STRIPE_SECRET_KEY']);

--- a/src/Controller/Api/TransactionController.php
+++ b/src/Controller/Api/TransactionController.php
@@ -14,10 +14,10 @@ use OpenApi\Attributes as OA;
 #[OA\Tag(name: 'Transaction')]
 class TransactionController extends AbstractController
 {
-    #[OA\Get(path: '/api/transactions/user/{id}', summary: 'List transactions by user')]
+    #[OA\Get(path: '/api/secure/transactions/user/{id}', summary: 'List transactions by user')]
     #[OA\Response(response: 200, description: 'Success')]
     #[OA\Response(response: 404, description: 'Not found')]
-    #[Route('/api/transactions/user/{id}', name: 'api_transactions_user', methods: ['GET'])]
+    #[Route('/api/secure/transactions/user/{id}', name: 'api_transactions_user', methods: ['GET'])]
     public function byUser(int $id, UtilisateurRepository $utilisateurRepository, TransactionRepository $transactionRepository): JsonResponse
     {
         $utilisateur = $utilisateurRepository->find($id);
@@ -43,10 +43,10 @@ class TransactionController extends AbstractController
         return $this->json($data);
     }
 
-    #[OA\Get(path: '/api/transactions/reservation/{id}', summary: 'List transactions by reservation')]
+    #[OA\Get(path: '/api/secure/transactions/reservation/{id}', summary: 'List transactions by reservation')]
     #[OA\Response(response: 200, description: 'Success')]
     #[OA\Response(response: 404, description: 'Not found')]
-    #[Route('/api/transactions/reservation/{id}', name: 'api_transactions_reservation', methods: ['GET'])]
+    #[Route('/api/secure/transactions/reservation/{id}', name: 'api_transactions_reservation', methods: ['GET'])]
     public function byReservation(int $id, ReservationRepository $reservationRepository, TransactionRepository $transactionRepository): JsonResponse
     {
         $reservation = $reservationRepository->find($id);


### PR DESCRIPTION
## Summary
- protect transaction endpoints
- protect Stripe payment route
- protect mail sending route

## Testing
- `php -l src/Controller/Api/TransactionController.php`
- `php -l src/Controller/Api/StripeController.php`
- `php -l src/Controller/Api/MailApiController.php`


------
https://chatgpt.com/codex/tasks/task_e_687d045bcdac8331802b0dfdeef86f2a