### PR TITLE
Fix delete annonce route path

### DIFF
--- a/src/Controller/Api/AnnonceController.php
+++ b/src/Controller/Api/AnnonceController.php
@@ -247,7 +247,7 @@ class AnnonceController extends AbstractController
 
     #[OA\Delete(path: '/api/secure/annonces/{id}', summary: 'Delete annonce')]
     #[OA\Response(response: 200, description: 'Success')]
-    #[Route('/api/annonces/{id}', name: 'api_annonces_delete', methods: ['DELETE'])]
+    #[Route('/api/secure/annonces/{id}', name: 'api_annonces_delete', methods: ['DELETE'])]
     public function delete(EntityManagerInterface $entityManager, Annonce $annonce): JsonResponse
     {
         $entityManager->remove($annonce);


### PR DESCRIPTION
## Summary
- point delete annonce route to `/api/secure/annonces/{id}`

## Testing
- `php -l src/Controller/Api/AnnonceController.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_687d042fb394833181f21215ea9e1152