### PR TITLE
Add annonce search endpoint

### DIFF
--- a/src/Controller/Api/AnnonceController.php
+++ b/src/Controller/Api/AnnonceController.php
@@ -21,11 +21,17 @@ use OpenApi\Attributes as OA;
 class AnnonceController extends AbstractController
 {
     #[OA\Get(path: '/api/annonces', summary: 'List annonces')]
+    #[OA\Parameter(name: 'q', in: 'query', description: 'Search term', required: false, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 200, description: 'Success')]
     #[Route('/api/annonces', name: 'api_annonces', methods: ['GET'])]
-    public function index(AnnonceRepository $annonceRepository, ParameterBagInterface $params): JsonResponse
+    public function index(Request $request, AnnonceRepository $annonceRepository, ParameterBagInterface $params): JsonResponse
     {
-        $annonces = $annonceRepository->findAll();
+        $search = $request->query->get('q');
+        if ($search) {
+            $annonces = $annonceRepository->searchByTerm($search);
+        } else {
+            $annonces = $annonceRepository->findAll();
+        }
         $endpoint = rtrim($params->get('minio_endpoint'), '/'); // évite les //
 
         $data = [];

--- a/src/Repository/AnnonceRepository.php
+++ b/src/Repository/AnnonceRepository.php
@@ -16,6 +16,24 @@ class AnnonceRepository extends ServiceEntityRepository
         parent::__construct($registry, Annonce::class);
     }
 
+    /**
+     * Search annonces by a string contained in titre or description or category label.
+     *
+     * @param string $term Search term
+     * @return Annonce[]
+     */
+    public function searchByTerm(string $term): array
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->leftJoin('a.categorie', 'c')
+            ->addSelect('c')
+            ->andWhere('LOWER(a.titre) LIKE :t OR LOWER(a.description) LIKE :t OR LOWER(c.label) LIKE :t')
+            ->setParameter('t', '%' . strtolower($term) . '%')
+            ->orderBy('a.id', 'DESC');
+
+        return $qb->getQuery()->getResult();
+    }
+
     //    /**
     //     * @return Annonce[] Returns an array of Annonce objects
     //     */


### PR DESCRIPTION
## Summary
- support search via `q` query param in annonce index
- implement repository search helper

## Testing
- `php -l src/Repository/AnnonceRepository.php`
- `php -l src/Controller/Api/AnnonceController.php`

------
https://chatgpt.com/codex/tasks/task_e_687d2ec153c88331b1b1c6f7280bb0dc